### PR TITLE
Specify PHP version requirement and ext-json for json_encode()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,8 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
+    "php": "^7.4|^8.0",
+    "ext-json": "*",
     "leafs/http": "*"
   }
 }


### PR DESCRIPTION
## Description

This PR adds PHP itself to the "required" key in composer.json, so that users can verify if this module works with their PHP version. Also, the JSON extension has been added, because the code uses "json_encode()" and it's considered good practice (and important) to list the required PHP runtime extensions.

Please note that I've set the PHP language level to 7.4, because all older 7.x versions are no longer receiving security support and have reached their end of life. However, judging from the features used in the code, PHP 7.1 would actually suffice.

Feel free to downgrade the PHP language level to 7.1.

Regards,
Tobias