### PR TITLE
Add initial tests for Form module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ vendor
 composer.lock
 composer
 .phpunit.result.cache
+.php-cs-fixer.cache
 
 #phpstorm
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ test
 Experimental
 vendor
 composer.lock
+composer
+.phpunit.result.cache
+
+#phpstorm
+.idea

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+$finder = PhpCsFixer\Finder::create()
+    ->in([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->name('*.php')
+    ->ignoreDotFiles(true)
+    ->ignoreVCS(true);
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR12' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'no_unused_imports' => true,
+        'not_operator_with_successor_space' => false,
+        'trailing_comma_in_multiline' => true,
+        'phpdoc_scalar' => true,
+        'unary_operator_spaces' => true,
+        'binary_operator_spaces' => true,
+        'blank_line_before_statement' => [
+            'statements' => ['break', 'continue', 'declare', 'return', 'throw', 'try'],
+        ],
+        'phpdoc_single_line_var_spacing' => true,
+        'phpdoc_var_without_name' => true,
+        'method_argument_space' => [
+            'on_multiline' => 'ensure_fully_multiline',
+            'keep_multiple_spaces_after_comma' => true,
+        ],
+        'single_trait_insert_per_statement' => true,
+    ])
+    ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,13 @@
   "prefer-stable": true,
   "require": {
     "leafs/http": "*"
+  },
+  "require-dev": {
+    "pestphp/pest": "^1.22"
+  },
+  "config": {
+    "allow-plugins": {
+      "pestphp/pest-plugin": true
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     "leafs/http": "*"
   },
   "require-dev": {
-    "pestphp/pest": "^1.22"
+    "pestphp/pest": "^1.22",
+    "friendsofphp/php-cs-fixer": "^3.0"
   },
   "config": {
     "allow-plugins": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./app</directory>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+use Leaf\Form;
+
+it("supports 11 default rules", function () {
+  $rules = Form::supportedRules();
+  expect($rules)->toBeArray();
+  expect(count($rules))->toBe(11);
+});
+
+it("has some known default rules", function () {
+  $rules = Form::supportedRules();
+  expect(in_array('required', $rules))->toBe(true);
+  expect(in_array('email', $rules))->toBe(true);
+});
+
+it("can add a custom rule", function () {
+  $rules = Form::supportedRules();
+  $rules_count = count($rules);
+  expect(in_array('custom_equal_rule', $rules))->toBe(false);
+
+  Form::rule("custom_equal_rule", function ($field, $value, $params) {
+    return $value == $params;
+  });
+
+  $rules = Form::supportedRules();
+  $new_rules_count = count($rules);
+  expect(in_array('custom_equal_rule', $rules))->toBe(true);
+  expect($new_rules_count)->toBe($rules_count + 1);
+});
+
+it("executes a custom rule", function () {
+  Form::rule("custom_equal_rule", function ($field, $value, $params) {
+    return $value == $params;
+  });
+
+  expect(Form::validateField("test", "example", "custom_equal_rule:example"))
+    ->toBe(true);
+  expect(Form::validateField("test", "wrong", "custom_equal_rule:example"))
+    ->toBe(false);
+});
+

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -4,21 +4,21 @@ declare(strict_types=1);
 use Leaf\Form;
 
 it("supports 11 default rules", function () {
-  $rules = Form::supportedRules();
-  expect($rules)->toBeArray();
-  expect(count($rules))->toBe(11);
+  expect(Form::supportedRules())
+    ->toBeArray()
+    ->toHaveCount(11);
 });
 
 it("has some known default rules", function () {
-  $rules = Form::supportedRules();
-  expect(in_array('required', $rules))->toBe(true);
-  expect(in_array('email', $rules))->toBe(true);
+  expect(Form::supportedRules())
+    ->toContain('required')
+    ->toContain('email');
 });
 
 it("can add a custom rule", function () {
   $rules = Form::supportedRules();
   $rules_count = count($rules);
-  expect(in_array('custom_equal_rule', $rules))->toBe(false);
+  expect($rules)->not()->toContain('custom_equal_rule');
 
   Form::rule("custom_equal_rule", function ($field, $value, $params) {
     return $value == $params;
@@ -26,7 +26,7 @@ it("can add a custom rule", function () {
 
   $rules = Form::supportedRules();
   $new_rules_count = count($rules);
-  expect(in_array('custom_equal_rule', $rules))->toBe(true);
+  expect($rules)->toContain('custom_equal_rule');
   expect($new_rules_count)->toBe($rules_count + 1);
 });
 

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -41,3 +41,16 @@ it("executes a custom rule", function () {
     ->toBe(false);
 });
 
+it("returns a custom error message", function () {
+  Form::rule("custom_equal_rule", function ($field, $value, $params) {
+    if ($value != $params) {
+      Form::addError($field, "This {field} did not work. {value} is not equal to {params}");
+      return false;
+    }
+    return true;
+  });
+
+  expect(Form::validateField("test", "wrong", "custom_equal_rule:example"))
+    ->toBe(false);
+  expect(Form::errors())->toHaveKey("test");
+});

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -1,56 +1,59 @@
 <?php
+
 declare(strict_types=1);
 
 use Leaf\Form;
 
 it("supports 11 default rules", function () {
-  expect(Form::supportedRules())
-    ->toBeArray()
-    ->toHaveCount(11);
+    expect(Form::supportedRules())
+      ->toBeArray()
+      ->toHaveCount(11);
 });
 
 it("has some known default rules", function () {
-  expect(Form::supportedRules())
-    ->toContain('required')
-    ->toContain('email');
+    expect(Form::supportedRules())
+      ->toContain('required')
+      ->toContain('email');
 });
 
 it("can add a custom rule", function () {
-  $rules = Form::supportedRules();
-  $rules_count = count($rules);
-  expect($rules)->not()->toContain('custom_equal_rule');
+    $rules = Form::supportedRules();
+    $rules_count = count($rules);
+    expect($rules)->not()->toContain('custom_equal_rule');
 
-  Form::rule("custom_equal_rule", function ($field, $value, $params) {
-    return $value == $params;
-  });
+    Form::rule("custom_equal_rule", function ($field, $value, $params) {
+        return $value == $params;
+    });
 
-  $rules = Form::supportedRules();
-  $new_rules_count = count($rules);
-  expect($rules)->toContain('custom_equal_rule');
-  expect($new_rules_count)->toBe($rules_count + 1);
+    $rules = Form::supportedRules();
+    $new_rules_count = count($rules);
+    expect($rules)->toContain('custom_equal_rule');
+    expect($new_rules_count)->toBe($rules_count + 1);
 });
 
 it("executes a custom rule", function () {
-  Form::rule("custom_equal_rule", function ($field, $value, $params) {
-    return $value == $params;
-  });
+    Form::rule("custom_equal_rule", function ($field, $value, $params) {
+        return $value == $params;
+    });
 
-  expect(Form::validateField("test", "example", "custom_equal_rule:example"))
-    ->toBe(true);
-  expect(Form::validateField("test", "wrong", "custom_equal_rule:example"))
-    ->toBe(false);
+    expect(Form::validateField("test", "example", "custom_equal_rule:example"))
+      ->toBe(true);
+    expect(Form::validateField("test", "wrong", "custom_equal_rule:example"))
+      ->toBe(false);
 });
 
 it("returns a custom error message", function () {
-  Form::rule("custom_equal_rule", function ($field, $value, $params) {
-    if ($value != $params) {
-      Form::addError($field, "This {field} did not work. {value} is not equal to {params}");
-      return false;
-    }
-    return true;
-  });
+    Form::rule("custom_equal_rule", function ($field, $value, $params) {
+        if ($value != $params) {
+            Form::addError($field, "This {field} did not work. {value} is not equal to {params}");
 
-  expect(Form::validateField("test", "wrong", "custom_equal_rule:example"))
-    ->toBe(false);
-  expect(Form::errors())->toHaveKey("test");
+            return false;
+        }
+
+        return true;
+    });
+
+    expect(Form::validateField("test", "wrong", "custom_equal_rule:example"))
+      ->toBe(false);
+    expect(Form::errors())->toHaveKey("test");
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+// uses(Tests\TestCase::class)->in('Feature');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+expect()->extend('toBeOne', function () {
+    return $this->toBe(1);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+function something()
+{
+    // ..
+}


### PR DESCRIPTION
## Description

Hi @mychidarko,

I've added some minimal tests for the form module. Those could be expanded to check that the default rules actually do what they are supposed to do, I've omitted that for now.

By the way, do you have a code style for leaf, which could be applied automatically? Something like PHP-CS-Fixer with PSR-12, Laravel Pint, prettier or the like?

Regards,
Tobias