### PR TITLE
Add support for nested fields in form validation resolves #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,17 @@ composer require leafs/form
 <?php
 
 $data = [
-  'name' => 'Full Name',
+  'name' => [
+    'first' => 'Jane',
+    'last' => 'Doe',
+  ],
   'email' => 'example@example.com',
   'password' => 'password1234',
 ];
 
 $success = form()->validate($data, [
-  'name' => 'required',
+  'name.first' => 'required',
+  'name.last' => 'required',
   'email' => 'required|email',
   'password' => 'required|min:8'
 ]);

--- a/src/Form.php
+++ b/src/Form.php
@@ -197,7 +197,7 @@ class Form
                     $rule[1] = trim($rule[1]);
                 }
 
-                $value = $data[$field] ?? null;
+                $value = Form::getDotNotatedValue($data, $field);
 
                 if (!static::test($rule[0], $value, $rule[1] ?? null, $field)) {
                     $params = is_string($rule[1] ?? null) ? trim($rule[1], '()') : ($rule[1] ?? null);
@@ -221,6 +221,24 @@ class Form
         }
 
         return $output;
+    }
+
+    /**
+     * Get the value from a nested array by key.
+     *
+     * @param array $array The array to search in.
+     * @param string $key The key to search for.
+     * @return mixed|null The value if found, null otherwise.
+     */
+    public static function getDotNotatedValue($array, $key) {
+        $keys = explode('.', $key);
+        foreach ($keys as $k) {
+            if (!isset($array[$k])) {
+                return null;
+            }
+            $array = $array[$k];
+        }
+        return $array;
     }
 
     /**

--- a/tests/nesting.test.php
+++ b/tests/nesting.test.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Leaf\Form;
+
+test('getDotNotatedValue retrieves simple field', function () {
+    $array = ['name' => 'Max'];
+    expect(Form::getDotNotatedValue($array, 'name'))->toBe('Max');
+});
+
+test('getDotNotatedValue returns null for non-existent field', function () {
+    $array = ['name' => 'Max'];
+    expect(Form::getDotNotatedValue($array, 'age'))->toBeNull();
+});
+
+test('getDotNotatedValue retrieves nested field', function () {
+    $nestedArray = [
+        'customer' => [
+            'phone' => '123456789',
+            'name' => 'Anna'
+        ],
+        'order' => [
+            'id' => 1
+        ]
+    ];
+    expect(Form::getDotNotatedValue($nestedArray, 'customer.phone'))->toBe('123456789');
+    expect(Form::getDotNotatedValue($nestedArray, 'customer.name'))->toBe('Anna');
+    expect(Form::getDotNotatedValue($nestedArray, 'order.id'))->toBe(1);
+});
+
+test('getDotNotatedValue retrieves deeply nested field', function () {
+    $deepNestedArray = [
+        'customer' => [
+            'details' => [
+                'address' => [
+                    'city' => 'Berlin'
+                ]
+            ]
+        ]
+    ];
+    expect(Form::getDotNotatedValue($deepNestedArray, 'customer.details.address.city'))->toBe('Berlin');
+});
+
+test('getDotNotatedValue returns null for non-existent nested field', function () {
+    $deepNestedArray = [
+        'customer' => [
+            'details' => [
+                'address' => [
+                    'city' => 'Berlin'
+                ]
+            ]
+        ]
+    ];
+    expect(Form::getDotNotatedValue($deepNestedArray, 'customer.details.phone'))->toBeNull();
+});


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## Description

<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This change adds the ability to validate nested arrays.

```php
<?php

$data = [
  'id' => 1,
  'user' => [
    'name' => [
      'first' => 'John',
      'last' => 'Doe',
    ],
    'password' => 'password1234',
    'email' => 'example@example.com',
  ],
];

$success = form()->validate($data, [
  'user.name.first' => 'required',
  'user.name.last' => 'required',
  'user.email' => 'required|email',
  'user.password' => 'required|min:8'
]);

if ($success) {
  // do something
} else {
  // get errors
  $errors = form()->errors();
}
```

- It doesn't break anything
- Tests run clean
- It allows validation of nested arrays (as you'd see in webhooks or if you like to group your data in forms)

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
#8 Add validation for multidimensional arrays