### PR TITLE
fix: improve validation logic for boolean fields

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -146,7 +146,7 @@ class Form
             $rule = $matches[0];
         }
 
-        if (in_array('optional', $rule) && empty($valueToTest)) {
+        if (in_array('optional', $rule) && ($valueToTest === null || $valueToTest === '' || $valueToTest === [])) {
             return true;
         }
 
@@ -175,7 +175,6 @@ class Form
                 $param = $ruleParams;
             }
 
-
             if (strpos($currentRule, ':') !== false && strpos($currentRule, '|') === false) {
                 $ruleParts = explode(':', $currentRule);
 
@@ -191,7 +190,8 @@ class Form
                 throw new \Exception("Rule $currentRule does not exist");
             }
 
-            if (!$valueToTest) {
+            $isMissing = $valueToTest === null || $valueToTest === '' || ($valueToTest === []);
+            if ($isMissing) {
                 if ($expandedErrors) {
                     $this->addError($fieldName, str_replace(
                         ['{field}', '{Field}', '{value}'],
@@ -245,6 +245,10 @@ class Form
 
             if (!is_array($param)) {
                 $param = [$param];
+            }
+
+            if (is_bool($valueToTest)) {
+                $valueToTest = $valueToTest ? '1' : '0';
             }
 
             if (is_float($valueToTest)) {


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## What kind of change does this PR introduce? (pls check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

I really appreciate the Leafs project and its simplicity.
I fixed a small bug in the validation system.
Basically, these types of checks always fail.

```php
$validatedData = $validator->validate(['booleankey' => false], ['booleankey' => 'boolean']);
```

The validator incorrectly treated false as a missing value, causing boolean validation to fail when the input was explicitly set to false.

Changes:

Updated the "required" check to only consider null, empty strings, and empty arrays as missing values.

Adjusted boolean handling so that false is properly converted to "0" before regex checks.

false is now recognized as a valid boolean value.

No impact on other validation rules or falsy values like 0 and "0".

